### PR TITLE
Support/ConexaoQA - Hide sensitive information from Report

### DIFF
--- a/api-conexaoQA/scanapi.conf
+++ b/api-conexaoQA/scanapi.conf
@@ -4,6 +4,6 @@ output_path: api-conexaoQA/reports/report.html # Report output path.
 report:
     hide_request:
         headers:
-          - Authorization
+          - Cookie
         body:
           - password


### PR DESCRIPTION
support: hide sensitive info of JWT from report > request > cookie